### PR TITLE
Normalization methods for encodings that use subtying "aliases".

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,43 @@ public class ExampleMonad<G, H> implements Monad<Hk<Hk<ExampleWitness, G>, H>> {
 
 It is not uncommon to create inheritance schemes or typealiases to represent HKTs of different arities. This allows avoiding conflicting function signatures due to generic type erasure in Java and improves readability, all at the expense of dealing with up/downcasting troubles.
 
+### Aliases via subtyping
+
+Library authors are not bound to use the `Hk` interface directly everywhere, they may use there own interfaces, as long as the root interface extends `io.kindedj.Hk`.
+
+Convenient support for multiple type parameters is one motivation for such aliases, eg. instead of:
+```java
+final class Tuple3<A, B, C> extends Hk<Hk<Hk<w, A>, B>, C> {
+  enum w{};
+  ...
+}
+```
+One may introduce the following aliases:
+```java
+interface Higher<F, A> extends Hk<F, A> {}
+
+interface Higher2<F, A, B> extends Higher<Higher<F, A>, B> {}
+
+interface Higher3<F, A, B, C> extends Higher2<Higher<F, A>, B, C> {}
+```
+and then have `Tuple3` extends `Higher3`:
+```java
+final class Tuple3<A, B, C> extends Higher3<w, A, B, C> {
+  enum w{};
+  ...
+}
+```
+
+However the introduction of such aliases may require a normalization step to recover the standard KindedJ encoding for the purpose of interoperability with the wider KindedJ ecosystem.
+KindedJ ship a small utility class providing those normalization methods: `io.kindedj.HCov`:
+```java
+  Higher3<w, A, B, C> t3 = ...;
+
+  Hk<Hk<Hk<w, A>, B>, C> normalizedT3 = HCov.covary3(t3)
+
+```
+
+
 ## Distribution
 
 Add as a dependency to your `build.gradle`

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ buildscript {
 
 allprojects {
     ext {
-        baseVersion = '1.0.1'
-        isSnapshot = false
+        baseVersion = '1.1.0'
+        isSnapshot = true
     }
 }
 

--- a/kindedj/src/main/java/io/kindedj/HCov.java
+++ b/kindedj/src/main/java/io/kindedj/HCov.java
@@ -1,0 +1,77 @@
+package io.kindedj;
+
+
+/**
+ * Methods to normalize HKT encodings that extends KindedJ encoding with subtyping aliases, using the fact that
+ * {@link Hk} is covariant in its first type variable argument (witness type of type constructor)
+ * because of the Liskov substitution principle.
+ */
+public final class HCov {
+  private HCov(){}
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B> Hk<Hk<f, A>, B> covary2(Hk<? extends Hk<f, A>, B> hk) {
+    return (Hk<Hk<f, A>, B>) hk;
+  }
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B, C> Hk<Hk<Hk<f, A>, B>, C> covary3(Hk<? extends Hk<? extends Hk<f, A>, B>, C> hk) {
+    return (Hk<Hk<Hk<f, A>, B>, C>) hk;
+  }
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B, C, D> Hk<Hk<Hk<Hk<f, A>, B>, C>, D> covary4(Hk<? extends Hk<? extends Hk<? extends Hk<f, A>, B>, C>, D>
+                                                                          hk) {
+    return (Hk<Hk<Hk<Hk<f, A>, B>, C>, D>) hk;
+  }
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B, C, D, E> Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E> covary5(Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<f, A>, B>, C>, D>, E> hk) {
+    return (Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>) hk;
+  }
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B, C, D, E, F> Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F> covary6(Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<f, A>, B>, C>, D>, E>, F> hk) {
+    return (Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F>) hk;
+  }
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B, C, D, E, F, G> Hk<Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F>, G> covary7(Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<f, A>, B>, C>, D>, E>, F>, G> hk) {
+    return (Hk<Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F>, G>) hk;
+  }
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B, C, D, E, F, G, H> Hk<Hk<Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F>, G>, H> covary8(Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<f, A>, B>, C>, D>, E>, F>, G>, H> hk) {
+    return (Hk<Hk<Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F>, G>, H>) hk;
+  }
+
+  /**
+   * Covary on type constructor witness to normalize to KindedJ encoding.
+   */
+  @SuppressWarnings("unchecked")
+  public static <f, A, B, C, D, E, F, G, H, I> Hk<Hk<Hk<Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F>, G>, H>, I> covary9(Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<? extends Hk<f, A>, B>, C>, D>, E>, F>, G>, H>, I> hk) {
+    return (Hk<Hk<Hk<Hk<Hk<Hk<Hk<Hk<Hk<f, A>, B>, C>, D>, E>, F>, G>, H>, I>) hk;
+  }
+
+}


### PR DESCRIPTION
Those methods are necessary to have proper compatibility with encodings that introduce alias interfaces that extends `io.kindedj.Hk` (because of no type alias in Java), eg. derive4j-hkt [`__2`](https://github.com/derive4j/hkt/blob/master/src/main/java/org/derive4j/hkt/__2.java#L9), `__3`, etc.

I could add those methods in `derive4j-hkt` but they are not specific and I suspect that they will be useful to other projects.